### PR TITLE
Fix build on Windows (msvc)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -28,6 +28,8 @@ fn main() -> Result<()> {
         }
     };
 
+    let target = std::env::var("TARGET").expect("The 'TARGET' environment variable MUST be set");
+
     let kernels : Vec<_>= KERNEL_FILES.iter().collect();
     let builder = bindgen_cuda::Builder::default().kernel_paths(kernels).out_dir(build_dir.clone())
                     .arg("-std=c++17")
@@ -48,7 +50,9 @@ fn main() -> Result<()> {
     println!("cargo:rustc-link-search={}", build_dir.display());
     println!("cargo:rustc-link-lib=rotary");
     println!("cargo:rustc-link-lib=dylib=cudart");
-    println!("cargo:rustc-link-lib=dylib=stdc++");
+    if !target.contains("msvc") {
+        println!("cargo:rustc-link-lib=dylib=stdc++");
+    }
 
     Ok(())
 }


### PR DESCRIPTION
1. Fixes stdc++ link error, msvc does not support and require `stdc++`, [example](https://github.com/spiceai/mistral.rs/blob/bea876ce81c61f881788c2ab9e2d3dc1dda9fe1e/mistralrs-core/build.rs#L49) 
